### PR TITLE
Handling sensor error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes for this project will be documented in this file
 
+## [0.49] - 2024-06-18
+### Added
+- Handling sensor error. If sensor fails during drying cycle, then drying process will be stopped and error message appear on the screen.
+  
 ## [0.48] - 2024-05-08
 ### changed
 - Refactoring Heating data. All values for heating power and heater fan speed are handled in an own class 

--- a/DryBoxControl.h
+++ b/DryBoxControl.h
@@ -20,7 +20,7 @@
 
 #include <Arduino.h>
 
-#define APP_VERSION "0.48"
+#define APP_VERSION "0.49"
 
 // Defines Pins
 #define FANAIR_PIN 9

--- a/DryBoxControl.ino
+++ b/DryBoxControl.ino
@@ -304,6 +304,15 @@ void loop() {
       ui100HzSensorTimer = 200;
       humidity = dht.readHumidity();
       temperature = dht.readTemperature();
+      // Check for NaN values
+      if (isnan(humidity) || isnan(temperature)) {
+        // Stop the drying process if NaN values are detected
+        dryController(DST_TEARDOWN, temperature);
+        display.ScreenOut(SCR_ERROR); 
+        display.PrintError("DHT Sensor Error"); // Display error message
+        AppState = AST_IDLE; // Transition to a safe state
+        //return; // Exit the loop to ensure the drying process is stopped
+      }
       if(AppState == AST_MODE_SELECT || AppState == AST_RUNDRYING || AppState == AST_TESTMODE) {
         display.PrintTHValue(temperature, humidity);
       }

--- a/DryBoxControl.ino
+++ b/DryBoxControl.ino
@@ -311,7 +311,6 @@ void loop() {
         display.ScreenOut(SCR_ERROR); 
         display.PrintError("DHT Sensor Error"); // Display error message
         AppState = AST_IDLE; // Transition to a safe state
-        //return; // Exit the loop to ensure the drying process is stopped
       }
       if(AppState == AST_MODE_SELECT || AppState == AST_RUNDRYING || AppState == AST_TESTMODE) {
         display.PrintTHValue(temperature, humidity);

--- a/DryBoxDisplay.cpp
+++ b/DryBoxDisplay.cpp
@@ -226,6 +226,14 @@ void DryBoxDisplay::PrintHFVState(boolean heater, boolean heaterfan, boolean ven
 
 }
 
+void DryBoxDisplay::PrintError(const char* errorMsg) {
+    lcd.clear();
+    lcd.setCursor(0, 0);
+    lcd.print("ERROR:");
+    lcd.setCursor(0, 1);
+    lcd.print(errorMsg);
+}
+
 void DryBoxDisplay::ScreenOut(uint8_t uiScreenID)
 {
 lcd.clear();
@@ -291,6 +299,11 @@ switch(uiScreenID)
     lcd.print("-Testing-|     C");
     lcd.setCursor(0,1);
     lcd.print("HFan  0% | H   %");    
-    break;  
+    break;
+
+  case SCR_ERROR:
+    lcd.setCursor(0, 0);
+    lcd.print("Error Screen");
+    break;
   }
 }

--- a/DryBoxDisplay.h
+++ b/DryBoxDisplay.h
@@ -26,6 +26,7 @@
 #define SCR_MENUBASE    10      // Basenumber Menu
 #define SCR_SETTEMP     20      // Set temperature
 #define SCR_SETTIME     30      // Set dry time
+#define SCR_ERROR       90
 
 #define SCR_RUNNING     40      // Show data for temperature and humidity
 #define SCR_RUNBREAK    41      // Run Drying paused or select stop 
@@ -57,6 +58,7 @@ public:
     void PrintDestTemp(int dvalue, uint8_t startPos);
     void PrintDestTime(int hour, int minute, uint8_t startPos);
     void PrintHFVState(boolean heater, boolean heaterfan, boolean ventilation, boolean turbomode);
-    void ScreenOut(uint8_t uiScreenID); 
+    void ScreenOut(uint8_t uiScreenID);
+    void PrintError(const char* errorMsg);
 
 };


### PR DESCRIPTION
If sensor fails during drying cycle, then drying process will be stopped and error message appear on the screen.