### PR TITLE
Enhance Drying Cycle Information Display, Add Fan Fail-Safe Settings, and Improve Heater Fan Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 All notable changes for this project will be documented in this file
 
+## [1.0] - 2024-06-30
+### Added
+New menu for setting fan fail RPM threshold and ability to save it in EEPROM.
+Option to turn off the fan fail-safe feature via the new menu.
+Rolling text display during the drying cycle, providing all necessary information.
+
+### changed
+The program now handles the heater fan differently; it will not turn off at the end of the drying cycle to avoid overheating of the PTC heater.
+Updated the way information is displayed during the drying cycle.
+
+### Fixed
+Bug where the drying cycle wouldn't stop when a fan fail event occurred.
+Miscellaneous
+Minor code adjustments.
+Code cleanup.
+Typo fixes.
+
 ## [0.5] - 2024-06-26
 ### Added
 - Added option to enable PTC fan tachomeret pin. If fan fails, drying process will be stopped and error message appear on the screen.

--- a/DryBoxControl.h
+++ b/DryBoxControl.h
@@ -20,7 +20,7 @@
 
 #include <Arduino.h>
 
-#define APP_VERSION "0.5"
+#define APP_VERSION "1.0"
 
 // Defines Pins
 #define FANAIR_PIN 9

--- a/DryBoxControl.ino
+++ b/DryBoxControl.ino
@@ -591,7 +591,7 @@ void loop() {
 
       case AST_ED_DRYHOUR:
         oldTimeVal = DryTime_Hours;
-        EncoderValueChange(&DryTime_Hours, 0, 9, 1, false);
+        EncoderValueChange(&DryTime_Hours, 0, 99, 1, false);
         if(oldTimeVal != DryTime_Hours)
         {
           display.PrintDestTime(DryTime_Hours, DryTime_Minutes, 0);

--- a/DryBoxControl.ino
+++ b/DryBoxControl.ino
@@ -71,8 +71,7 @@
 
 // Define the tachometer pin
 #define FAN_PIN 3 // Pin where the fan's tachometer output is connected
-bool haveTachometer = false;
-int tRPM = 300;  //Threshold of fan rpm error
+int tRPM = -1;  //Threshold of fan rpm error. -1 == Off feature
 volatile int rpmCounter = 0; // Counter for the tachometer pulses
 int rpm = 0;
 bool rpmUpdate = false;
@@ -640,8 +639,6 @@ void loop() {
           if(curDryTime_Minutes > 0) {
             curDryTime_Minutes--;
             display.PrintHFVState(temperature, humidity);
-																		   
-               
           } else {
             if(curDryTime_Hours > 0) {
               curDryTime_Hours--;
@@ -701,9 +698,7 @@ void loop() {
           dryController(0, temperature);
           AppState = AST_RUNDRYING;
           display.ScreenOut(SCR_RUNNING);
-          display.PrintHFVState(temperature, humidity);         
-												   
-																		 
+          display.PrintHFVState(temperature, humidity);  											 
         }    
 
         if(encoderBUTTON_State == 1 && aktBreakModNo == 2) // stop

--- a/DryBoxControl.ino
+++ b/DryBoxControl.ino
@@ -321,7 +321,7 @@ void RollingMessage(boolean StateHeaterOn, boolean StateHeaterFanOn, boolean Sta
   {
     char rpmBuf[6];
     strcat(buf, ", PTC FAN RPM = ");
-    itoa(tRPM, rpmBuf, 10);
+    itoa(rpm, rpmBuf, 10);
     strcat(buf, rpmBuf);
   }
   //Add more information if needed. Increase buf size accordingly.

--- a/DryBoxDisplay.cpp
+++ b/DryBoxDisplay.cpp
@@ -22,9 +22,10 @@ LiquidCrystal_I2C lcd(0x27,2,1,0,4,5,6,7,3,POSITIVE);
 
 char szVersion[17] = "";
 
-char szModNames[7][12] = {
+char szModNames[8][12] = {
   "Temp: 40C",
   "Time: 0:00",
+  "tRPM: 300",
   "-> Start",
   "-> Save",
   "-> Version",
@@ -38,6 +39,41 @@ char szTestNames[4][12] = {
   "Heat  0%",
   "AFan  0%"
 };
+
+int textLength; 
+int lcdWidth = 16; // Adjust based on your LCD's character width
+int scrollDelay = 250; // Adjust scroll speed (milliseconds)
+unsigned long previousScrollMillis = 0;
+int scrollPosition = 0;
+
+void scrollText(const char* longText) 
+{
+  unsigned long currentMillis = millis();
+
+  if (currentMillis - previousScrollMillis >= scrollDelay) 
+  {
+    previousScrollMillis = currentMillis;
+
+    int printedChars = 0;
+    lcd.setCursor(0, 1); 
+
+    for (int i = scrollPosition; i < scrollPosition + lcdWidth; i++) 
+    {
+      int index = i % textLength;
+      if (longText[index] != '\0') 
+      {
+        lcd.print(longText[index]);
+        printedChars++;
+      }
+      if (printedChars >= lcdWidth) 
+        break;      
+    }
+    
+    scrollPosition++;
+    if (scrollPosition >= textLength) 
+      scrollPosition = 0;     
+  }
+}
 
 DryBoxDisplay::DryBoxDisplay(/* args */)
 {
@@ -148,12 +184,10 @@ void DryBoxDisplay::PrintPercentValue(int pValue)
 {
   char buf[6]="";
   char valBuf[6]="";
-  int i,l;
-
+  int l;
   strcpy(valBuf,"  ");
   itoa(pValue, buf,10);
-  l = strlen(buf);
-  
+  l = strlen(buf);  
   strcpy(&valBuf[2-l], buf);
   strcat(valBuf, "%");
   lcd.setCursor(5,1);
@@ -162,7 +196,7 @@ void DryBoxDisplay::PrintPercentValue(int pValue)
 }
 
 void DryBoxDisplay::FanRPM(int rpm)
-{
+{  
   lcd.setCursor(4, 1);
   lcd.print("     ");
   lcd.setCursor(4, 1);
@@ -171,26 +205,44 @@ void DryBoxDisplay::FanRPM(int rpm)
 
 void DryBoxDisplay::PrintDestTemp(int dValue, uint8_t startPos)
 {
-  char buf[4]="";
-  char valBuf[6]="";
-  int i,l;
+  char buf[5] = ""; 
+  lcd.setCursor(startPos, 1);
+  lcd.print("     "); 
+  lcd.noCursor();
+  itoa(dValue, buf, 10);
+  strcat(buf, "\xDF");
+  strcat(buf, "C");
+  lcd.setCursor(startPos, 1);
+  lcd.print(buf);
+}
 
-  strcpy(valBuf,"  ");
-  itoa(dValue, buf,10);
-  l = strlen(buf);
-  
-  strcpy(&valBuf[2-l], buf);
-  
-  lcd.setCursor(0 + startPos,1);
-  lcd.print(valBuf);
+void DryBoxDisplay::PrintDestRPM(int dValue, uint8_t startPos) 
+{  
+  char buf[5] = ""; 
+  lcd.setCursor(startPos, 1);
+  lcd.print("    "); 
+  lcd.noCursor();
+  if (dValue >= 0) 
+  {
+    itoa(dValue, buf, 10);
+    lcd.setCursor(startPos, 1);
+    lcd.print(buf);
+  } 
+  else 
+  {
+    lcd.setCursor(startPos, 1);
+    lcd.print("OFF");
+  }
 }
 
 void DryBoxDisplay::PrintDestTime(int hour, int minute, uint8_t startPos)
 {
   char buf[4]="";
   char valBuf[6]="";
-  int i,l;
-
+  int l;
+  lcd.setCursor(startPos, 1);
+  lcd.print("     "); 
+  
   // convert hour
   strcpy(valBuf,"0:00");
   itoa(hour, buf,10);
@@ -198,40 +250,23 @@ void DryBoxDisplay::PrintDestTime(int hour, int minute, uint8_t startPos)
 
   // convert minutes
   itoa(minute, buf,10);
-  l = strlen(buf);
-  
-  strcpy(&valBuf[2+2-l], buf);
-  
+  l = strlen(buf);  
+  strcpy(&valBuf[2+2-l], buf);  
   lcd.setCursor(0 + startPos,1);
   lcd.print(valBuf);
 }
-
-//lcd.print("-RUN- HFV|     C");
-void DryBoxDisplay::PrintHFVState(boolean heater, boolean heaterfan, boolean ventilation, boolean turbomode)
-{
-  char szBuf[2] = "";
-  char szOneChar[2] = " ";
-
-  lcd.setCursor(5 , 0);
-  strcpy(szBuf, szOneChar);
-  if(turbomode == true) strcpy(szBuf, "T");
-  lcd.print(szBuf);
-
-  lcd.setCursor(6 , 0);
-  strcpy(szBuf, szOneChar);
-  if(heater == true) strcpy(szBuf, "H");
-  lcd.print(szBuf);
-
-  lcd.setCursor(7 , 0);
-  strcpy(szBuf, szOneChar);
-  if(heaterfan == true) strcpy(szBuf, "F");
-  lcd.print(szBuf);  
-
-  lcd.setCursor(8 , 0);
-  strcpy(szBuf, szOneChar);
-  if(ventilation == true) strcpy(szBuf, "V");
-  lcd.print(szBuf);    
-
+void DryBoxDisplay::PrintHFVState(int temp, int humid) {
+    lcd.setCursor(0, 0);
+    String tempStr = String(temp);
+    String humidStr = String(humid);    
+    String message = "RUN " + tempStr + "\xDF" + "C, H" + humidStr;
+    int remainingSpace = 16 - message.length() - 1; 
+    String spaces = "";
+    while (remainingSpace-- > 0) {
+        spaces += " ";
+    }
+    message = "RUN " + spaces + tempStr + "\xDF" + "C, H" + humidStr + "%";
+    lcd.print(message);
 }
 
 void DryBoxDisplay::PrintError(const char* errorMsg) {
@@ -240,6 +275,11 @@ void DryBoxDisplay::PrintError(const char* errorMsg) {
     lcd.print("ERROR:");
     lcd.setCursor(0, 1);
     lcd.print(errorMsg);
+}
+
+void DryBoxDisplay::DisScrollText(const char* scrollMsg) {
+    textLength = strlen(scrollMsg);
+    scrollText(scrollMsg);
 }
 
 void DryBoxDisplay::ScreenOut(uint8_t uiScreenID)
@@ -266,32 +306,34 @@ switch(uiScreenID)
     lcd.print("|  saved       |");
     break;
 
-  case SCR_MENUBASE:
-    //lcd.setCursor(0,0);
-    lcd.print("[ Select ]     C");
-    lcd.setCursor(0,1);
-    lcd.print("Temp: 40C  H   %");
+  case SCR_MENUBASE:						 
+    lcd.print("[ Select ]    ");
+    lcd.write(byte(223));
+    lcd.print("C");
+    lcd.setCursor(0, 1);
+    lcd.print("Temp: 40C   H  %");
     break;
 
-  case SCR_SETTEMP:
-    //lcd.setCursor(0,0);
+  case SCR_SETTEMP:						 
     lcd.print("[ Set Dry Temp ]");
     lcd.setCursor(0,1);
-    lcd.print("40 DegreeC | RET");
+    lcd.print("40C        | RET");
     break;
 
-  case SCR_SETTIME:
-    //lcd.setCursor(0,0);
+  case SCR_SETTIME:						 
     lcd.print("[ Set Dry Time ]");
     lcd.setCursor(0,1);
     lcd.print("1:30  h:mm | RET");  
     break;
 
-  case SCR_RUNNING:
-    //lcd.setCursor(0,0);
-    //TODO: adjust screen for showing the state of Heater, Heaterfan and Ventilation
-    //lcd.print("-Running-|     C");
-      lcd.print("-RUN- HFV|     C");
+  case SCR_SETRPM:
+    lcd.print("Set threshld RPM");
+    lcd.setCursor(0,1);
+    lcd.print("300    RPM | RET");  
+    break;
+
+  case SCR_RUNNING:	
+    lcd.print("-RUN-          C");
     lcd.setCursor(0,1);
     lcd.print("35C h5:30| H   %");    
     break;
@@ -302,16 +344,15 @@ switch(uiScreenID)
     lcd.print("cont stop|");      
     break;
   
-  case SCR_TESTING:
-    //lcd.setCursor(0,0);
+  case SCR_TESTING:						 
     lcd.print("-Testing-|     C");
     lcd.setCursor(0,1);
     lcd.print("HFan  0% | H   %");    
-    break;
+    break; 
 
   case SCR_ERROR:
     lcd.setCursor(0, 0);
     lcd.print("Error Screen");
-    break;
+    break; 
   }
 }

--- a/DryBoxDisplay.cpp
+++ b/DryBoxDisplay.cpp
@@ -205,7 +205,7 @@ void DryBoxDisplay::FanRPM(int rpm)
 
 void DryBoxDisplay::PrintDestTemp(int dValue, uint8_t startPos)
 {
-  char buf[5] = ""; 
+  char buf[7] = ""; 
   lcd.setCursor(startPos, 1);
   lcd.print("     "); 
   lcd.noCursor();

--- a/DryBoxDisplay.cpp
+++ b/DryBoxDisplay.cpp
@@ -237,23 +237,34 @@ void DryBoxDisplay::PrintDestRPM(int dValue, uint8_t startPos)
 
 void DryBoxDisplay::PrintDestTime(int hour, int minute, uint8_t startPos)
 {
-  char buf[4]="";
-  char valBuf[6]="";
-  int l;
-  lcd.setCursor(startPos, 1);
-  lcd.print("     "); 
-  
-  // convert hour
-  strcpy(valBuf,"0:00");
-  itoa(hour, buf,10);
-  valBuf[0] = buf[0];    // copy a single digit into the outbuf
+    char buf[4] = "";
+    String valStr = "";
+    int l;
 
-  // convert minutes
-  itoa(minute, buf,10);
-  l = strlen(buf);  
-  strcpy(&valBuf[2+2-l], buf);  
-  lcd.setCursor(0 + startPos,1);
-  lcd.print(valBuf);
+    lcd.setCursor(startPos, 1);
+    lcd.print("     "); 
+
+    // Convert hour
+    itoa(hour, buf, 10);
+    valStr += buf; // Append hour
+
+    // Add colon
+    valStr += ":";
+
+    // Convert minutes
+    itoa(minute, buf, 10);
+    if (minute < 10) {
+        valStr += "0"; 
+    }
+    valStr += buf; 
+
+    int actualStartPos = startPos;
+    if (hour < 10) {
+        actualStartPos -= 1;
+    }
+
+    lcd.setCursor(actualStartPos, 1);
+    lcd.print(valStr);
 }
 void DryBoxDisplay::PrintHFVState(int temp, int humid) {
     lcd.setCursor(0, 0);

--- a/DryBoxDisplay.h
+++ b/DryBoxDisplay.h
@@ -26,6 +26,7 @@
 #define SCR_MENUBASE    10      // Basenumber Menu
 #define SCR_SETTEMP     20      // Set temperature
 #define SCR_SETTIME     30      // Set dry time
+#define SCR_SETRPM      31      // Set threshold RPM
 #define SCR_ERROR       90
 
 #define SCR_RUNNING     40      // Show data for temperature and humidity
@@ -56,10 +57,11 @@ public:
     void PrintTHValue(float temp, float humidity);
     void PrintPercentValue(int pValue);
     void PrintDestTemp(int dvalue, uint8_t startPos);
-    void PrintDestTime(int hour, int minute, uint8_t startPos);
-    void PrintHFVState(boolean heater, boolean heaterfan, boolean ventilation, boolean turbomode);
-    void ScreenOut(uint8_t uiScreenID);
+    void PrintDestTime(int hour, int minute, uint8_t startPos);																								  
+    void ScreenOut(uint8_t uiScreenID); 
     void PrintError(const char* errorMsg);
     void FanRPM(int rpm);
-
+    void PrintDestRPM(int rpm, uint8_t startPos);
+    void DisScrollText(const char* scrollMsg);
+    void PrintHFVState (int temp, int humid);
 };

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DryBox dryController
 ===
 
-## Version 0.5
+## Version 1.0
 
 ## Requirements
 - Arduino IDE 1.8.2 or higher


### PR DESCRIPTION
Features:
Rolling text display during the drying cycle.
Menu for setting fan fail RPM threshold with EEPROM saving and option to disable fail-safe.

Bug Fix:
Drying cycle now stops on fan fail.

Changes:
Heater fan stays on at the end of the cycle to prevent overheating.
Improved information display.
Includes minor code adjustments, cleanup, and typo fixes.